### PR TITLE
Adding the possibility to request products by multiply identifiers.

### DIFF
--- a/src/test/java/com/j2bugzilla/rpc/TestGetProduct.java
+++ b/src/test/java/com/j2bugzilla/rpc/TestGetProduct.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ import org.mockito.stubbing.Answer;
 import com.j2bugzilla.base.BugzillaConnector;
 import com.j2bugzilla.base.BugzillaException;
 import com.j2bugzilla.base.ProductVersion;
+import com.j2bugzilla.base.Product;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestGetProduct {
@@ -78,12 +80,82 @@ public class TestGetProduct {
 		
 		assertEquals("Product ID is incorrect", 1, product.getProduct().getID());
 		assertEquals("Product name is incorrect", "Test", product.getProduct().getName());
-		assertEquals("Product name is incorrect", 1, product.getProduct().getProductVersions().size());
+		assertEquals("versions number is incorrect", 1, product.getProduct().getProductVersions().size());
 		
 		ProductVersion version = product.getProduct().getProductVersions().get(0);
 		assertEquals("Product version ID is incorrect", 17, version.getID());
 		assertEquals("Product version name is incorrect", "1.0", version.getName());
 		
+	}
+
+	@Test
+	public void testManyProducts() throws BugzillaException {
+		GetProduct product = new GetProduct(new int[]{1, 2, 7});
+		
+		doAnswer(new Answer<Void>() {
+
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				GetProduct rpcMethod = (GetProduct)invocation.getArguments()[0];
+				
+				Map<Object, Object> hash = new HashMap<Object, Object>();
+				Object[] productArray = new Object[3];
+				
+				Map<Object, Object> product;
+
+				//versions
+				Map<String, Object> version = new HashMap<String, Object>();
+				version.put("id", 17);
+				version.put("name", "1.0");
+				Object[] versions = {version};
+
+				//				
+				product = new HashMap<Object, Object>();
+				product.put("id", 1);
+				product.put("name", "Test1");
+				product.put("versions", versions);
+				productArray[0]	 = product;
+				//
+				product = new HashMap<Object, Object>();
+				product.put("id", 2);
+				product.put("name", "Test2");
+				product.put("versions", versions);
+				productArray[1]	 = product;
+				//
+				product = new HashMap<Object, Object>();
+				product.put("id", 7);
+				product.put("name", "Test7");
+				product.put("versions", versions);
+				productArray[2]	 = product;
+
+				hash.put("products", productArray);
+				rpcMethod.setResultMap(hash);
+				
+				return null;
+			}
+			
+		}).when(conn).executeMethod(product);
+		
+		conn.executeMethod(product);
+
+		assertEquals("Result size is incorrect", 3, product.getProducts().size());
+		List<Product> products = product.getProducts();
+
+		assertEquals("Product1 ID is incorrect", 1, products.get(0).getID());
+		assertEquals("Product1 name is incorrect", "Test1", products.get(0).getName());
+		assertEquals("Product1 versions number is incorrect", 1, products.get(0).getProductVersions().size());
+
+		assertEquals("Product2 ID is incorrect", 2, products.get(1).getID());
+		assertEquals("Product2 name is incorrect", "Test2", products.get(1).getName());
+		assertEquals("Product2 versions number is incorrect", 1, products.get(1).getProductVersions().size());
+
+		assertEquals("Product3 ID is incorrect", 7, products.get(2).getID());
+		assertEquals("Product3 name is incorrect", "Test7", products.get(2).getName());
+		assertEquals("Product3 versions number is incorrect", 1, products.get(2).getProductVersions().size());
+
+		ProductVersion version = products.get(0).getProductVersions().get(0);
+		assertEquals("Product version ID is incorrect", 17, version.getID());
+		assertEquals("Product version name is incorrect", "1.0", version.getName());
 	}
 	
 	@Test


### PR DESCRIPTION
Bugzilla API supports requesting product details by multiply identifiers. But J2Bugzilla currently allows clients to request details only for one product at time. It causes the problems for the library users who need to request details for multiply products and connection to Bugzilla server is not fast enough.
Please review my changes and if they are valid, it would be great if you include them into the next j2Bugzilla release.